### PR TITLE
Black Duck: Upgrade Newtonsoft.Json to version 13.0.1 fix known security vulerabilities

### DIFF
--- a/src/Senders/FluentEmail.Mailgun/FluentEmail.Mailgun.csproj
+++ b/src/Senders/FluentEmail.Mailgun/FluentEmail.Mailgun.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<?xml version='1.0' encoding='utf8'?>
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Send emails via MailGun using their REST API</Description>
@@ -8,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade Newtonsoft.Json from version 12.0.3 to 13.0.1 in order to fix security vulnerabilities:

The direct dependency Newtonsoft.Json/12.0.3 has 1 vulnerabilities (max score 6.7).


| Parent | Child Component | Vulnerability | Score |  Policy Violated | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| / | Newtonsoft.Json/12.0.3 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2018-5195/overview" target="_blank">BDSA-2018-5195</a> | <span style="color:Orange">6.7</span> | Vulnerabilities | Newtonsoft.Json is vulnerable to denial-of-service (DoS) due to a stack overflow that can occur whenever nested objects are being processed. A remote attacker could cause a vulnerable application to c ... | 12.0.3 |


